### PR TITLE
Skip tests fixes

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/sim/tests/test_sim.py
+++ b/sherpa/astro/sim/tests/test_sim.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/tests/test_data.py
+++ b/sherpa/astro/tests/test_data.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/tests/test_plot.py
+++ b/sherpa/astro/tests/test_plot.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/tests/test_nan.py
+++ b/sherpa/astro/ui/tests/test_nan.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2013  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2013, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/ui/tests/test_ui.py
+++ b/sherpa/astro/ui/tests/test_ui.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2012  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -19,9 +19,8 @@
 
 import unittest
 import numpy
-import sherpa.astro.xspec as xs
 from sherpa.astro import ui
-from sherpa.utils import SherpaTestCase, test_data_missing
+from sherpa.utils import SherpaTestCase, test_data_missing, has_package_from_list
 
 import logging
 error = logging.getLogger(__name__).error
@@ -34,9 +33,12 @@ def is_proper_subclass(obj, cls):
     return issubclass(obj, cls)
 
 
+@unittest.skipIf(not has_package_from_list('sherpa.astro.xspec'),
+                         "required package sherpa.astro.xspec not available")
 class test_xspec(SherpaTestCase):
 
     def test_create_model_instances(self):
+        import sherpa.astro.xspec as xs
         count = 0
 
         for cls in dir(xs):
@@ -53,6 +55,7 @@ class test_xspec(SherpaTestCase):
         self.assertEqual(count, 164)
 
     def test_evaluate_model(self):
+        import sherpa.astro.xspec as xs
         m = xs.XSbbody()
         out = m([1,2,3,4])
         if m.calc.__name__.startswith('C_'):
@@ -64,6 +67,7 @@ class test_xspec(SherpaTestCase):
 
 
     def test_xspec_models(self):
+        import sherpa.astro.xspec as xs
         models = [model for model in dir(xs) if model[:2] == 'XS']
         models.remove('XSModel')
         models.remove('XSMultiplicativeModel')
@@ -107,12 +111,13 @@ class test_xspec(SherpaTestCase):
         self.assertAlmostEqual(y_m, y2_m)
 
     def test_xsxset_get(self):
+        import sherpa.astro.xspec as xs
 	# TEST CASE #1 Case insentitive keys
 	xs.set_xsxset('fooBar', 'somevalue')
 	self.assertEqual('somevalue', xs.get_xsxset('Foobar'))
 
 
 if __name__ == '__main__':
-
+    import sherpa.astro.xspec as xs
     from sherpa.utils import SherpaTest
     SherpaTest(xs).test()

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -20,6 +20,7 @@
 import unittest
 import numpy
 import os
+import sherpa
 from sherpa.image import *
 from sherpa.utils import SherpaTestCase, has_package_from_list
 
@@ -54,7 +55,7 @@ class test_image(SherpaTestCase):
         @unittest.skipIf(not has_package_from_list('sherpa.image.ds9_backend'),
                          "reqiured package sherpa.image.ds9_backend not available")
         def test_ds9(self):
-            im = sherpa.image.ds9_backend.DS9Win(sherpa.image.ds9_backend._DefTemplate, False)
+            im = sherpa.image.ds9_backend.DS9.DS9Win(sherpa.image.ds9_backend.DS9._DefTemplate, False)
             im.doOpen()
             im.showArray(data.y)
             data_out = get_arr_from_imager(im)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2011  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2012  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2012, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,5 +1,5 @@
 # 
-#  Copyright (C) 2007  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- `import sherpa` and fix error on this line in the original pull request:
  https://github.com/sherpa/sherpa/pull/10/files#diff-7f4e3ad74bd90eae5be1dea0d84d9ca3R57
- Updated copyright year.
- If you `python setup.py develop` then the xspec tests will be skipped if xspec is missing.

The changes were tested by integrating PR sherpa/sherpa#21 and by building sherpa + running `sherpa_test`. Since I had some unpublished work on my local copy I also integrated the `snapshot` branch and my unpublished branch in order to test the fixes with `python setup.py develop` and `python setup.py test`.

To test the xspec-related changes, I built sherpa with the xspec extension on Linux64@cxc, and then ran both `sherpa_test` (with the full regression tests enabled) and `python setup.py test`. Everything seems to check.
